### PR TITLE
podspec ready to push

### DIFF
--- a/ISO8601.podspec
+++ b/ISO8601.podspec
@@ -17,7 +17,6 @@ Pod::Spec.new do |s|
   s.requires_arc = false
 
   s.source_files = 'ISO8601/NJISO8601Formatter.{h,m}', 'ISO8601/NJISO8601Parser.{h,m}'
-  s.resources = 'tools/*'
 
   # s.prepare_command = <<-CMD
   #    ./Tools/re2c -cs -t "./ISO8601/NJISO8601Parser.h" -o "./ISO8601/NJISO8601Parser.m" ./ISO8601/NJISO8601Parser.re

--- a/ISO8601/AppDelegate.h
+++ b/ISO8601/AppDelegate.h
@@ -3,7 +3,6 @@
  *  ISO8601
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 . All rights reserved.
  *
  */
 

--- a/ISO8601/AppDelegate.m
+++ b/ISO8601/AppDelegate.m
@@ -3,7 +3,6 @@
  *  ISO8601
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 . All rights reserved.
  *
  */
 

--- a/ISO8601/ISO8601-Info.plist
+++ b/ISO8601/ISO8601-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>jp.naver.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>com.yourcompany.${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/ISO8601/NJISO8601Formatter.h
+++ b/ISO8601/NJISO8601Formatter.h
@@ -3,7 +3,6 @@
  *  NJFoundation
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 NHN. All rights reserved.
  *
  */
 

--- a/ISO8601/NJISO8601Formatter.m
+++ b/ISO8601/NJISO8601Formatter.m
@@ -3,7 +3,6 @@
  *  NJFoundation
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 NHN. All rights reserved.
  *
  */
 

--- a/ISO8601/NJISO8601Parser.re
+++ b/ISO8601/NJISO8601Parser.re
@@ -3,7 +3,6 @@
  *  NJFoundation
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 NHN. All rights reserved.
  *
  */
 

--- a/ISO8601/ViewController.h
+++ b/ISO8601/ViewController.h
@@ -3,7 +3,6 @@
  *  ISO8601
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 . All rights reserved.
  *
  */
 

--- a/ISO8601/ViewController.m
+++ b/ISO8601/ViewController.m
@@ -3,7 +3,6 @@
  *  ISO8601
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 . All rights reserved.
  *
  */
 

--- a/ISO8601/main.m
+++ b/ISO8601/main.m
@@ -3,7 +3,6 @@
  *  ISO8601
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 . All rights reserved.
  *
  */
 

--- a/ISO8601Tests/ISO8601Tests-Info.plist
+++ b/ISO8601Tests/ISO8601Tests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>jp.naver.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>com.yourcompany.${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/ISO8601Tests/NJISO8601FormatterTests.h
+++ b/ISO8601Tests/NJISO8601FormatterTests.h
@@ -3,7 +3,6 @@
  *  NJFoundation
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 NHN. All rights reserved.
  *
  */
 

--- a/ISO8601Tests/NJISO8601FormatterTests.m
+++ b/ISO8601Tests/NJISO8601FormatterTests.m
@@ -3,7 +3,6 @@
  *  NJFoundation
  *
  *  Created by han9kin on 2012-03-21.
- *  Copyright (c) 2012 NHN. All rights reserved.
  *
  */
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright (c) 2012, han9kin
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,22 @@
 Copyright (c) 2012, han9kin
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/NJISO8601.podspec
+++ b/NJISO8601.podspec
@@ -5,8 +5,8 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  s.name             = "ISO8601"
-  s.version          = "0.1.9"
+  s.name             = "NJISO8601"
+  s.version          = "0.2.0"
   s.summary          = "ISO8601 formatter"
   s.homepage         = "http://github.com/PAM-AS/"
   # s.screenshots      = "www.example.com/screenshots_1", "www.example.com/screenshots_2"

--- a/NJISO8601.podspec
+++ b/NJISO8601.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.summary          = "ISO8601 formatter"
   s.homepage         = "http://github.com/PAM-AS/"
   # s.screenshots      = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
-  # s.license          = 'MIT'
+  s.license          = 'BSD'
   s.author           = { "han9kin" => "han9kin@gmail.com" }
   s.source           = { :git => "https://github.com/PAM-AS/iso8601.git", :tag => s.version.to_s }
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Installation
+
+NJISO8601 is available through [CocoaPods](http://cocoapods.org). To install
+it, simply add the following line to your Podfile:
+
+    pod "NJISO8601"
+
 ## Fork note
 
 This fork contains prebuilt files to work with cocoapods. This may not be optimal.


### PR DESCRIPTION
exclude re2c from pod since it's unused by simply installing pod, rename to NJISO8601 since there's already an ISO8601 pod, ref'd license, bumped version, now pod spec lint passes.  @thomassnielsen do you want to push it from your fork or should we:  git tag 0.2.0 && git push origin 0.2.0 && pod trunk push
